### PR TITLE
Remove unused imports from accross the codebase.

### DIFF
--- a/src/app/graph-editor/services/visio-to-mxgraph.service.ts
+++ b/src/app/graph-editor/services/visio-to-mxgraph.service.ts
@@ -11,7 +11,6 @@ import {
     Position,
     GraphLayer
 } from '../../tracing/visio/layout-engine/datatypes';
-import * as _ from 'lodash';
 
 declare const mxConstants: any;
 

--- a/src/app/graph-editor/state/graph-editor.reducer.ts
+++ b/src/app/graph-editor/state/graph-editor.reducer.ts
@@ -1,6 +1,5 @@
-import * as fromRoot from '../../state/app.state';
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { GraphEditorActions, GraphEditorActionTypes, GraphEditorActivated } from './graph-editor.actions';
+import { GraphEditorActions, GraphEditorActionTypes } from './graph-editor.actions';
 
 export const STATE_SLICE_NAME = 'graphEditor';
 

--- a/src/app/main-page/presentation/avatar/avatar.component.ts
+++ b/src/app/main-page/presentation/avatar/avatar.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { User } from '../../../user/models/user.model';
-import { Observable } from 'rxjs';
 
 @Component({
     selector: 'fcl-avatar',

--- a/src/app/tracing/configuration/abstract-rule-edit-view.ts
+++ b/src/app/tracing/configuration/abstract-rule-edit-view.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { OperationType, TableColumn } from '@app/tracing/data.model';
 import { ComplexFilterCondition, PropToValuesMap } from './configuration.model';
-import * as _ from 'lodash';
 import { EditRule } from './model';
 import { isEditRuleValid, validateEditRule } from './edit-rule-validaton';
 

--- a/src/app/tracing/configuration/colors-and-shapes-edit-view/colors-and-shapes-edit-view.component.ts
+++ b/src/app/tracing/configuration/colors-and-shapes-edit-view/colors-and-shapes-edit-view.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnChanges, SimpleChanges } from '@angular/core';
 import { Color, NodeShapeType } from '@app/tracing/data.model';
-import * as _ from 'lodash';
 import { ColorAndShapeEditRule } from '../model';
 import { AbstractRuleEditViewComponent } from '../abstract-rule-edit-view';
 import { COLOR_BFR_BLUE } from '../constants';

--- a/src/app/tracing/configuration/configuration.effects.ts
+++ b/src/app/tracing/configuration/configuration.effects.ts
@@ -16,7 +16,6 @@ import { DialogYesNoComponent, DialogYesNoData } from '../dialog/dialog-yes-no/d
 import { selectHighlightingSettings } from '../state/tracing.selectors';
 import { EditHighlightingService } from './edit-highlighting.service';
 import { TableColumn } from '../data.model';
-import * as _ from 'lodash';
 
 @Injectable()
 export class ConfigurationEffects {

--- a/src/app/tracing/configuration/edge-color-edit-view/edge-color-edit-view.component.ts
+++ b/src/app/tracing/configuration/edge-color-edit-view/edge-color-edit-view.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnChanges, SimpleChanges } from '@angular/core';
 import { Color } from '@app/tracing/data.model';
-import * as _ from 'lodash';
 import { ColorEditRule } from '../model';
 import { AbstractRuleEditViewComponent } from '../abstract-rule-edit-view';
 

--- a/src/app/tracing/configuration/edit-highlighting.service.ts
+++ b/src/app/tracing/configuration/edit-highlighting.service.ts
@@ -33,7 +33,6 @@ import {
     convertDeliveryEditRuleToHRule, convertStationEditRuleToHRule
 } from './rule-conversion';
 import { EditRuleOfType, extractPropToValuesMap } from './shared';
-import * as _ from 'lodash';
 
 interface UnsharedData {
     propData: PropData;

--- a/src/app/tracing/configuration/filter-elements-view/filter-elements-view.component.ts
+++ b/src/app/tracing/configuration/filter-elements-view/filter-elements-view.component.ts
@@ -16,7 +16,6 @@ import { extractPropToValuesMap, filterTableRows } from '../shared';
 import {
     InputData as FilterTableViewInputData, TableFilterChange
 } from '../filter-table-view/filter-table-view.component';
-import * as _ from 'lodash';
 import { FilterTableSettings, ShowType, ComplexFilterCondition, PropToValuesMap, ActivityState } from '../configuration.model';
 import { ComplexFilterUtils } from '../shared/complex-filter-utils';
 import { Observable, Subject } from 'rxjs';

--- a/src/app/tracing/configuration/filter-table-view/filter-table-utils.ts
+++ b/src/app/tracing/configuration/filter-table-view/filter-table-utils.ts
@@ -5,7 +5,6 @@ import {
     orderByComparator
 } from '@swimlane/ngx-datatable';
 import { NodeShapeType, TableRow } from '@app/tracing/data.model';
-import * as _ from 'lodash';
 
 type SortableColumn = Pick<NgxTableColumn, 'prop' | 'comparator'>;
 type RowComparator = (vA: any, vB: any, rA: TableRow, rB: TableRow, sortDir?: SortDirection) => number;

--- a/src/app/tracing/configuration/highlighting-delivery-view/highlighting-delivery-view.component.ts
+++ b/src/app/tracing/configuration/highlighting-delivery-view/highlighting-delivery-view.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnChanges, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
-import * as _ from 'lodash';
 import { DeliveryEditRule, RuleType } from '../model';
 import { HighlightingElementViewComponent } from '../highlighting-element-view/highlighting-element-view.component';
 

--- a/src/app/tracing/configuration/highlighting-element-view/highlighting-element-view.component.ts
+++ b/src/app/tracing/configuration/highlighting-element-view/highlighting-element-view.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { TableColumn } from '@app/tracing/data.model';
 import { HighlightingRuleDeleteRequestData, PropToValuesMap } from '../configuration.model';
-import * as _ from 'lodash';
 import { EditRule, RuleId, RuleListItem, RuleType } from '../model';
 import { removeNullishPick } from '@app/tracing/util/non-ui-utils';
 

--- a/src/app/tracing/configuration/highlighting-station-view/highlighting-station-view.component.ts
+++ b/src/app/tracing/configuration/highlighting-station-view/highlighting-station-view.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnChanges, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
-import * as _ from 'lodash';
 import { RuleType, StationEditRule } from '../model';
 import { HighlightingElementViewComponent } from '../highlighting-element-view/highlighting-element-view.component';
 

--- a/src/app/tracing/configuration/label-rules-edit-view/label-rules-edit-view.component.ts
+++ b/src/app/tracing/configuration/label-rules-edit-view/label-rules-edit-view.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, OnChanges, SimpleChanges } from '@angular/core';
-import * as _ from 'lodash';
 import { SimpleLabelEditRule } from '../model';
 import { AbstractRuleEditViewComponent } from '../abstract-rule-edit-view';
 import { getCompleteConditionsCount, getNonEmptyConditionCount } from '../edit-rule-validaton';

--- a/src/app/tracing/configuration/rule-conversion.ts
+++ b/src/app/tracing/configuration/rule-conversion.ts
@@ -2,7 +2,6 @@ import {
     DeliveryHighlightingRule, HighlightingRule, HighlightingStats,
     LinePatternType, StationHighlightingRule
 } from '../data.model';
-import { Utils } from '../util/non-ui-utils';
 import {
     ColorAndShapeEditRule, ColorEditRule, ComposedLabelEditRule,
     DeliveryEditRule, DeliveryRuleType, EditRule, EditRuleCore,

--- a/src/app/tracing/configuration/shared/complex-filter-utils.ts
+++ b/src/app/tracing/configuration/shared/complex-filter-utils.ts
@@ -1,6 +1,5 @@
 import { DataTable, LogicalCondition, TableColumn } from '@app/tracing/data.model';
 import { ComplexFilterCondition, JunktorType } from '../configuration.model';
-import * as _ from 'lodash';
 import { RequiredPick } from '@app/tracing/util/utility-types';
 
 type SimpleValueType = string | number | boolean | undefined | null;

--- a/src/app/tracing/configuration/table-cells/collapse-status-cell-view/collapse-status-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/collapse-status-cell-view/collapse-status-cell-view.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 import { TreeStatus } from '@app/tracing/data.model';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-collapse-status-cell-view',

--- a/src/app/tracing/configuration/table-cells/opensettings-header-cell-view/opensettings-header-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/opensettings-header-cell-view/opensettings-header-cell-view.component.ts
@@ -1,7 +1,6 @@
 import {
     Component, ChangeDetectionStrategy
 } from '@angular/core';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-opensettings-header-cell-view',

--- a/src/app/tracing/configuration/table-cells/row-cell-view/row-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/row-cell-view/row-cell-view.component.ts
@@ -1,7 +1,6 @@
 import {
     Component, Input, ChangeDetectionStrategy
 } from '@angular/core';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-row-cell-view',

--- a/src/app/tracing/configuration/table-cells/selectcolumns-header-cell-view/symbol-header-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/selectcolumns-header-cell-view/symbol-header-cell-view.component.ts
@@ -1,7 +1,6 @@
 import {
     Component, Input, Output, EventEmitter, ChangeDetectionStrategy
 } from '@angular/core';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-symbol-header-cell-view',

--- a/src/app/tracing/configuration/table-cells/symbol-cell-view/symbol-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/symbol-cell-view/symbol-cell-view.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { TableRow } from '@app/tracing/data.model';
 import { Constants } from '@app/tracing/util/constants';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-symbol-cell-view',

--- a/src/app/tracing/configuration/table-cells/visibility-cell-view/visibility-cell-view.component.ts
+++ b/src/app/tracing/configuration/table-cells/visibility-cell-view/visibility-cell-view.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { TableRow } from '@app/tracing/data.model';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-visibility-cell-view',

--- a/src/app/tracing/graph/components/geomap/geomap.component.ts
+++ b/src/app/tracing/graph/components/geomap/geomap.component.ts
@@ -5,7 +5,6 @@ import {
     MapType,
     Size, MapConfig
 } from '../../../data.model';
-import * as _ from 'lodash';
 import { createOpenLayerMap, updateMapType, updateVectorLayerStyle } from '@app/tracing/util/map-utils';
 
 interface TypedSimpleChange<T> extends SimpleChange {

--- a/src/app/tracing/graph/components/gis-graph/gis-graph.component.ts
+++ b/src/app/tracing/graph/components/gis-graph/gis-graph.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/co
 import { Subscription } from 'rxjs';
 import html2canvas from 'html2canvas';
 import { GraphType, Layout, GisGraphState, LegendDisplayEntry } from '../../../data.model';
-import * as _ from 'lodash';
 import { Action, Store } from '@ngrx/store';
 import { ContextMenuRequestInfo, GraphServiceData } from '../../graph.model';
 import { GraphService } from '../../graph.service';

--- a/src/app/tracing/graph/components/graph-view/graph-view.component.ts
+++ b/src/app/tracing/graph/components/graph-view/graph-view.component.ts
@@ -3,7 +3,6 @@ import {
     EventEmitter, OnChanges, ChangeDetectionStrategy, SimpleChanges
 } from '@angular/core';
 import { Size, Layout, PositionMap } from '../../../data.model';
-import * as _ from 'lodash';
 import { ContextMenuRequestInfo, EdgeId, NodeId, SelectedGraphElements } from '../../graph.model';
 import { StyleConfig } from '../../cy-graph/cy-style';
 import { VirtualZoomCyGraph } from '../../cy-graph/virtual-zoom-cy-graph';

--- a/src/app/tracing/graph/components/schema-graph/schema-graph.component.ts
+++ b/src/app/tracing/graph/components/schema-graph/schema-graph.component.ts
@@ -2,7 +2,6 @@ import { Component, ElementRef, OnInit, ViewChild, OnDestroy } from '@angular/co
 import { Subscription } from 'rxjs';
 import html2canvas from 'html2canvas';
 import { GraphType, LegendDisplayEntry, SchemaGraphState } from '../../../data.model';
-import * as _ from 'lodash';
 import { Action, Store } from '@ngrx/store';
 import { ContextMenuRequestInfo, GraphServiceData } from '../../graph.model';
 import { GraphService } from '../../graph.service';

--- a/src/app/tracing/graph/context-menu.service.ts
+++ b/src/app/tracing/graph/context-menu.service.ts
@@ -9,7 +9,6 @@ import {
     GraphServiceData,
     NodeId
 } from './graph.model';
-import * as _ from 'lodash';
 import { MenuItemData } from './menu-item-data.model';
 import { MenuItemStrings } from './menu.constants';
 import {

--- a/src/app/tracing/graph/cy-graph/cy-graph.ts
+++ b/src/app/tracing/graph/cy-graph/cy-graph.ts
@@ -2,7 +2,6 @@ import { CyNodeData, CyEdgeData, Cy, CyNodeDef, CyEdgeDef, SelectedGraphElements
 import { Layout, Position, PositionMap } from '../../data.model';
 import cytoscape from 'cytoscape';
 import { StyleConfig, CyStyle } from './cy-style';
-import * as _ from 'lodash';
 import { EdgeLabelOffsetUpdater } from '../edge-label-offset-updater';
 import { EDGE_GROUP, NODE_GROUP, PRESET_LAYOUT_NAME } from './cy.constants';
 import cola from 'cytoscape-cola';

--- a/src/app/tracing/graph/cy-graph/cy-style.ts
+++ b/src/app/tracing/graph/cy-graph/cy-style.ts
@@ -1,5 +1,4 @@
 import cytoscape from 'cytoscape';
-import { Style } from 'ol/style';
 import { GraphElementData } from '../graph.model';
 import { CSS_CLASS_HOVER } from './cy.constants';
 

--- a/src/app/tracing/graph/cy-graph/position-based-viewport-fitting.ts
+++ b/src/app/tracing/graph/cy-graph/position-based-viewport-fitting.ts
@@ -1,6 +1,5 @@
 import { getEnclosingRectFromPoints } from '@app/tracing/util/geometry-utils';
 import { Layout, Size, Range, Position } from '../../data.model';
-import _ from 'lodash';
 
 const DEFAULT_VIEWPORT = { zoom: 1, pan: { x: 0, y: 0 } };
 

--- a/src/app/tracing/graph/schema-graph.service.ts
+++ b/src/app/tracing/graph/schema-graph.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { StationId, Position, SchemaGraphState } from '../data.model';
 import { GraphService } from './graph.service';
 import { CyNodeData, NodeId } from './graph.model';
-import * as _ from 'lodash';
 import { GraphData } from './cy-graph/cy-graph';
 
 @Injectable({

--- a/src/app/tracing/grouping/grouping.service.ts
+++ b/src/app/tracing/grouping/grouping.service.ts
@@ -4,7 +4,6 @@ import {
     GroupType, GroupData, ObservedType, GroupMode, Position, StationTracingSettings
 } from '../data.model';
 import { concat, removeNullish, Utils } from '../util/non-ui-utils';
-import * as _ from 'lodash';
 import { GroupingState, GroupingChange, SetStationGroupsPayload } from './model';
 import { SourceCollapser } from './source-collapser';
 import { TargetCollapser } from './target-collapser';

--- a/src/app/tracing/io/data-importer/sample-importer-v1.ts
+++ b/src/app/tracing/io/data-importer/sample-importer-v1.ts
@@ -1,6 +1,5 @@
 import { SampleData as IntSampleData, FclData, SampleResultType } from '../../data.model';
 import { JsonData } from '../ext-data-model.v1';
-import * as Constants from './../ext-data-constants.v1';
 
 export function importSamples(rawData: any, fclData: FclData) {
     fclData.fclElements.samples = convertRawSamples(rawData);

--- a/src/app/tracing/io/data-mappings/data-mappings-v0-to-v1.ts
+++ b/src/app/tracing/io/data-mappings/data-mappings-v0-to-v1.ts
@@ -1,6 +1,5 @@
 import { DeliveryData } from '../../data.model';
 import { Map as ImmutableMap } from 'immutable';
-import * as _ from 'lodash';
 
 export const DELIVERY_PROP_V0_TO_V1_MAP: ImmutableMap<
     string,

--- a/src/app/tracing/io/data-mappings/data-mappings-v1.ts
+++ b/src/app/tracing/io/data-mappings/data-mappings-v1.ts
@@ -19,7 +19,6 @@ import {
     DEL2DEL_PROP_TO_REQ_TYPE_MAP
 } from '../int-data-constants';
 import { isValueTypeValid } from './shared';
-import * as _ from 'lodash';
 import { InputDataError } from '../io-errors';
 
 export interface ColumnInfo {

--- a/src/app/tracing/io/ext-data-constants.v1.ts
+++ b/src/app/tracing/io/ext-data-constants.v1.ts
@@ -1,5 +1,3 @@
-import { Map as ImmutableMap } from 'immutable';
-
 export const STATION_ADDRESS = 'Address';
 export const STATION_COUNTRY = 'Country';
 export const STATION_FORWARD = 'Forward';

--- a/src/app/tracing/layout/farm-to-fork/data-structures.ts
+++ b/src/app/tracing/layout/farm-to-fork/data-structures.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-
 export class Graph {
     vertices: Vertex[] = [];
     layers: Vertex[][];

--- a/src/app/tracing/services/data.service.spec.ts
+++ b/src/app/tracing/services/data.service.spec.ts
@@ -3,9 +3,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { DataService } from './data.service';
 import {
-    CrossContTraceType, DataServiceData, DataServiceInputState,
-    DeliveryData, StationData
-} from '../data.model';
+    CrossContTraceType, DataServiceInputState} from '../data.model';
 import { createDefaultHighlights } from '../io/data-importer/shared';
 import { createDefaultPropMappings } from '../state/tracing.reducers';
 

--- a/src/app/tracing/util/map-utils.ts
+++ b/src/app/tracing/util/map-utils.ts
@@ -7,7 +7,6 @@ import { Tile } from 'ol/layer';
 import VectorSource from 'ol/source/Vector';
 import { GeoJSON } from 'ol/format';
 import { Stroke, Style } from 'ol/style';
-import * as _ from 'lodash';
 import { InputDataError } from '../io/io-errors';
 import { StyleLike } from 'ol/style/Style';
 import { NotNullish, NotNullishPick } from './utility-types';

--- a/src/app/tracing/visio/layout-engine/box-creator.ts
+++ b/src/app/tracing/visio/layout-engine/box-creator.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { VisioBox, StationInformation, LotInformation, GraphLayer, GridCell,
     StationSampleInformation, SampleInformation, BoxType, Size,
     VisioConnector, VisioPort, InSampleInformation } from './datatypes';

--- a/src/app/tracing/visio/layout-engine/cell-grouper.ts
+++ b/src/app/tracing/visio/layout-engine/cell-grouper.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { GridCell } from './datatypes';
 import { StationData } from '../../data.model';
 import { Utils } from './../../util/non-ui-utils';

--- a/src/app/tracing/visio/layout-engine/farm-to-fork.ts
+++ b/src/app/tracing/visio/layout-engine/farm-to-fork.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { StationData, DeliveryData, StationId, DeliveryId, Range } from '../../data.model';
 import { Graph, Vertex } from '../../layout/farm-to-fork/data-structures';
 import { FarmToForkLayouter } from '../../layout/farm-to-fork/farm-to-fork';

--- a/src/app/tracing/visio/layout-engine/sample-information-provider.ts
+++ b/src/app/tracing/visio/layout-engine/sample-information-provider.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { SampleData } from '../../data.model';
 import { StationInformation, LotInformation,
     SampleInformation, InSampleInformation, StationSampleInformation } from './datatypes';

--- a/src/app/tracing/visio/layout-engine/station_positioner_lp.ts
+++ b/src/app/tracing/visio/layout-engine/station_positioner_lp.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { lpSolve, LPModel } from './../../../shared/lp-solver';
 import { VisioBox, VisioConnector } from './datatypes';
 

--- a/src/app/tracing/visio/layout-engine/stationbox-simple-grouper.ts
+++ b/src/app/tracing/visio/layout-engine/stationbox-simple-grouper.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { VisioBox, Position, Size, BoxType } from './datatypes';
 import { LabelCreator } from './label-creator';
 import { GraphSettings } from './graph-settings';

--- a/src/app/user/container/activate-container/activate-container.component.ts
+++ b/src/app/user/container/activate-container/activate-container.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { environment } from '../../../../environments/environment';
-import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 
 import { UserService } from '../../services/user.service';

--- a/src/app/user/container/admin-activate-container/admin-activate-container.component.ts
+++ b/src/app/user/container/admin-activate-container/admin-activate-container.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { HttpErrorResponse } from '@angular/common/http';
 
 import { UserService } from '../../services/user.service';
 import { AlertService } from '../../../shared/services/alert.service';

--- a/src/app/user/container/profile-container/profile-container.component.ts
+++ b/src/app/user/container/profile-container/profile-container.component.ts
@@ -1,9 +1,6 @@
 import { Component } from '@angular/core';
-import { TokenizedUser } from '../../models/user.model';
 import * as fromUser from '../../../user/state/user.reducer';
 import { Store, select } from '@ngrx/store';
-import { Observable } from 'rxjs';
-import * as _ from 'lodash';
 
 @Component({
     selector: 'fcl-profile-container',

--- a/src/app/user/presentation/profile/profile.component.spec.ts
+++ b/src/app/user/presentation/profile/profile.component.spec.ts
@@ -6,7 +6,6 @@ import { ProfileComponent } from './profile.component';
 import { MaterialModule } from '../../../shared/material.module';
 import { SharedModule } from '../../../shared/shared.module';
 import { TokenizedUser } from '../../models/user.model';
-import { By } from '@angular/platform-browser';
 
 describe('ProfileComponent', () => {
 


### PR DESCRIPTION
Unnecessary imports refer to importing modules, libraries, or dependencies that are not used or referenced anywhere in the code. These imports do not contribute to the functionality of the application and only add extra weight to the JavaScript bundle, leading to potential performance and maintainability issues.